### PR TITLE
Provided a return value of int for result and updated function signa…

### DIFF
--- a/cp210x.c
+++ b/cp210x.c
@@ -1551,7 +1551,7 @@ static int cp210x_gpio_get(struct gpio_chip *gc, unsigned int gpio)
 	return !!(mask & BIT(gpio));
 }
 
-static void cp210x_gpio_set(struct gpio_chip *gc, unsigned int gpio, int value)
+static int cp210x_gpio_set(struct gpio_chip *gc, unsigned int gpio, int value)
 {
 	struct usb_serial *serial = gpiochip_get_data(gc);
 	struct cp210x_serial_private *priv = usb_get_serial_data(serial);
@@ -1607,6 +1607,7 @@ out:
 		dev_err(&serial->interface->dev, "failed to set GPIO value: %d\n",
 				result);
 	}
+	return result;
 }
 
 static int cp210x_gpio_direction_get(struct gpio_chip *gc, unsigned int gpio)


### PR DESCRIPTION
…ture for static int cp210x_gpio_set(struct gpio_chip *gc, unsigned int gpio, int value) to return an int

Tested and works with Adafruit Ultimate GNSS GPS with PPS over USB on a Pi5 running 6.18.29+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.18.29-1+rpt1 (2026-05-12) aarch64 GNU/Linux